### PR TITLE
added cash handout information link

### DIFF
--- a/src/Notice.svelte
+++ b/src/Notice.svelte
@@ -82,6 +82,17 @@
         href="https://fukuoka.stopcovid19.jp/"
         title={$t('link.fukuoka')} />
     </li>
+    <li>
+      <ExternalLink
+        href="https://fukuoka.stopcovid19.jp/"
+        title={$t('link.fukuoka')} />
+    </li>
+
+    <li>
+      <ExternalLink
+        href="https://kyufukin.soumu.go.jp/ja-JP/apply/"
+        title={$t('link.cashHandout')} />
+    </li>
   </ul>
   <hr />
 </div>

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -22,6 +22,7 @@ const translation = {
     tokyo: 'COVID-19 Tokyo Information Website',
     fukuoka: 'COVID-19 Fukuoka Information Website',
     checkDetail: 'Check out more details on Fukuoka official website.',
+    cashHandout: 'Cash Handout (Japanese)',
   },
   data: {
     patients: 'Fukuoka Open Data - COVID-19 Patients Information',

--- a/src/i18n/ja.js
+++ b/src/i18n/ja.js
@@ -22,6 +22,7 @@ const translation = {
     tokyo: '東京新型コロナウイルス感染症対策サイト',
     fukuoka: '新型冠狀病毒對策網站（福岡）',
     checkDetail: '詳しくは福岡公式サイトへ',
+    cashHandout: '特別定額給付金',
   },
   data: {
     patients: 'Fukuoka Open Data - 新型コロナウイルス感染症　陽性患者発表情報',

--- a/src/i18n/zh-TW.js
+++ b/src/i18n/zh-TW.js
@@ -22,6 +22,7 @@ const translation = {
     tokyo: '新型冠狀病毒對策網站（東京）',
     fukuoka: '新型冠狀病毒對策網站（福岡）',
     checkDetail: '詳細請到福岡官方網站',
+    cashHandout: '特別定額給付金',
   },
   data: {
     patients: '福岡開放資料 - 新型冠狀病毒陽性患者情報',


### PR DESCRIPTION
1. [總務省](https://www.soumu.go.jp/menu_seisaku/gyoumukanri_sonota/covid-19/kyufukin.html)

2. [Apply Cash handout](https://kyufukin.soumu.go.jp/ja-JP/apply/)